### PR TITLE
feat: AnlayticsManager 생성 (#94)

### DIFF
--- a/Toucher/Toucher.xcodeproj/project.pbxproj
+++ b/Toucher/Toucher.xcodeproj/project.pbxproj
@@ -81,12 +81,19 @@
 		29F1D51F2AA84E240074C1FE /* PinchImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F1D51E2AA84E240074C1FE /* PinchImageView.swift */; };
 		321F51642B5C2B1F0066CB17 /* GuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321F51632B5C2B1F0066CB17 /* GuideView.swift */; };
 		321F51662B5E54480066CB17 /* URLManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321F51652B5E54480066CB17 /* URLManager.swift */; };
+		323F138E2B87BE83008D240E /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 323F138D2B87BE83008D240E /* AdSupport.framework */; };
 		324D77402B7B6731000B5BB6 /* BackGroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 324D773F2B7B6731000B5BB6 /* BackGroundColor.swift */; };
 		3266082E2B31E5EB006A58B8 /* LaunchScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3266082D2B31E5EB006A58B8 /* LaunchScreenView.swift */; };
 		326608302B31E78E006A58B8 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3266082F2B31E78E006A58B8 /* OnboardingView.swift */; };
 		326608322B31EC01006A58B8 /* TapButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326608312B31EC01006A58B8 /* TapButton.swift */; };
 		3288A8322B483DAC00A95A26 /* PanViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3288A8312B483DAC00A95A26 /* PanViewModel.swift */; };
 		32A178412B25E35B007A3CAB /* CustomToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A178402B25E35B007A3CAB /* CustomToolbar.swift */; };
+		32AB7AC12B87AFEC00DC6158 /* AnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AB7AC02B87AFEC00DC6158 /* AnalyticsManager.swift */; };
+		32AB7AC32B87B2E700DC6158 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 32AB7AC22B87B2E700DC6158 /* FirebaseAnalytics */; };
+		32AB7AC52B87B2E700DC6158 /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 32AB7AC42B87B2E700DC6158 /* FirebaseAnalyticsOnDeviceConversion */; };
+		32AB7AC72B87B2E700DC6158 /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 32AB7AC62B87B2E700DC6158 /* FirebaseAnalyticsSwift */; };
+		32AB7AC92B87B2E700DC6158 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 32AB7AC82B87B2E700DC6158 /* FirebaseAnalyticsWithoutAdIdSupport */; };
+		32AB7ACB2B87B2E700DC6158 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 32AB7ACA2B87B2E700DC6158 /* FirebaseAppCheck */; };
 		32EC3F5A2B2F898F0017F9E0 /* PanMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EC3F592B2F898F0017F9E0 /* PanMap.swift */; };
 		F06CACF02B468C610024E366 /* Arrows.swift in Sources */ = {isa = PBXBuildFile; fileRef = F06CACEF2B468C610024E366 /* Arrows.swift */; };
 		F06CACF32B4693960024E366 /* LongTapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F06CACF22B4693960024E366 /* LongTapViewModel.swift */; };
@@ -161,12 +168,14 @@
 		29F1D51E2AA84E240074C1FE /* PinchImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchImageView.swift; sourceTree = "<group>"; };
 		321F51632B5C2B1F0066CB17 /* GuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideView.swift; sourceTree = "<group>"; };
 		321F51652B5E54480066CB17 /* URLManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLManager.swift; sourceTree = "<group>"; };
+		323F138D2B87BE83008D240E /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		324D773F2B7B6731000B5BB6 /* BackGroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackGroundColor.swift; sourceTree = "<group>"; };
 		3266082D2B31E5EB006A58B8 /* LaunchScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenView.swift; sourceTree = "<group>"; };
 		3266082F2B31E78E006A58B8 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		326608312B31EC01006A58B8 /* TapButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapButton.swift; sourceTree = "<group>"; };
 		3288A8312B483DAC00A95A26 /* PanViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanViewModel.swift; sourceTree = "<group>"; };
 		32A178402B25E35B007A3CAB /* CustomToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToolbar.swift; sourceTree = "<group>"; };
+		32AB7AC02B87AFEC00DC6158 /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
 		32EC3F592B2F898F0017F9E0 /* PanMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanMap.swift; sourceTree = "<group>"; };
 		F06CACEF2B468C610024E366 /* Arrows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Arrows.swift; sourceTree = "<group>"; };
 		F06CACF22B4693960024E366 /* LongTapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongTapViewModel.swift; sourceTree = "<group>"; };
@@ -183,18 +192,24 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				323F138E2B87BE83008D240E /* AdSupport.framework in Frameworks */,
+				32AB7AC32B87B2E700DC6158 /* FirebaseAnalytics in Frameworks */,
 				29BCA2F62B5021AB009D6DEF /* FirebaseDatabase in Frameworks */,
 				29BCA2FC2B5021AB009D6DEF /* FirebaseFirestore in Frameworks */,
 				29BCA2E82B5021AB009D6DEF /* FirebaseAnalyticsSwift in Frameworks */,
 				29BCA2E42B5021AB009D6DEF /* FirebaseAnalytics in Frameworks */,
 				29BCA2E62B5021AB009D6DEF /* FirebaseAnalyticsOnDeviceConversion in Frameworks */,
 				29BCA3002B5021AB009D6DEF /* FirebaseFirestoreSwift in Frameworks */,
+				32AB7AC52B87B2E700DC6158 /* FirebaseAnalyticsOnDeviceConversion in Frameworks */,
 				29BCA2F02B5021AB009D6DEF /* FirebaseAuth in Frameworks */,
+				32AB7AC92B87B2E700DC6158 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
 				29BCA2F42B5021AB009D6DEF /* FirebaseCrashlytics in Frameworks */,
 				29BCA2F82B5021AB009D6DEF /* FirebaseDatabaseSwift in Frameworks */,
 				29BCA3182B5021AB009D6DEF /* FirebaseStorageCombine-Community in Frameworks */,
+				32AB7AC72B87B2E700DC6158 /* FirebaseAnalyticsSwift in Frameworks */,
 				29BCA2F22B5021AB009D6DEF /* FirebaseAuthCombine-Community in Frameworks */,
 				29BCA3162B5021AB009D6DEF /* FirebaseStorage in Frameworks */,
+				32AB7ACB2B87B2E700DC6158 /* FirebaseAppCheck in Frameworks */,
 				29BCA2FE2B5021AB009D6DEF /* FirebaseFirestoreCombine-Community in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -235,6 +250,7 @@
 				076655592AA22A1E00DC6687 /* DeviceManager.swift */,
 				295A06242B271B56004CAF1C /* NavigationManager.swift */,
 				321F51652B5E54480066CB17 /* URLManager.swift */,
+				32AB7AC02B87AFEC00DC6158 /* AnalyticsManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -298,6 +314,7 @@
 				29EAB40B2AA17DAE004E5429 /* .swiftlint.yml */,
 				29E8521D2AA08346003F4AF4 /* Toucher */,
 				29E8521C2AA08346003F4AF4 /* Products */,
+				323F138C2B87BE83008D240E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -414,6 +431,14 @@
 			path = Pinch;
 			sourceTree = "<group>";
 		};
+		323F138C2B87BE83008D240E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				323F138D2B87BE83008D240E /* AdSupport.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		32A1783F2B25E350007A3CAB /* Header */ = {
 			isa = PBXGroup;
 			children = (
@@ -508,6 +533,11 @@
 				29BCA2FF2B5021AB009D6DEF /* FirebaseFirestoreSwift */,
 				29BCA3152B5021AB009D6DEF /* FirebaseStorage */,
 				29BCA3172B5021AB009D6DEF /* FirebaseStorageCombine-Community */,
+				32AB7AC22B87B2E700DC6158 /* FirebaseAnalytics */,
+				32AB7AC42B87B2E700DC6158 /* FirebaseAnalyticsOnDeviceConversion */,
+				32AB7AC62B87B2E700DC6158 /* FirebaseAnalyticsSwift */,
+				32AB7AC82B87B2E700DC6158 /* FirebaseAnalyticsWithoutAdIdSupport */,
+				32AB7ACA2B87B2E700DC6158 /* FirebaseAppCheck */,
 			);
 			productName = Toucher;
 			productReference = 29E8521B2AA08346003F4AF4 /* Toucher.app */;
@@ -622,6 +652,7 @@
 				29EAB4202AA62EC2004E5429 /* LongTapCameraButtonView.swift in Sources */,
 				29D51B782B25A29300A6923E /* MainViewModel.swift in Sources */,
 				297805452B481C490019D138 /* RotateViewModel.swift in Sources */,
+				32AB7AC12B87AFEC00DC6158 /* AnalyticsManager.swift in Sources */,
 				29EAB41E2AA62D41004E5429 /* LongTapButtonView.swift in Sources */,
 				29D51B812B25BF6100A6923E /* FinishMainView.swift in Sources */,
 				07D345EE2AA8716500B7329D /* SwipeViewModel.swift in Sources */,
@@ -800,6 +831,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Toucher/Preview Content\"";
 				DEVELOPMENT_TEAM = WF2V4JB29M;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
@@ -834,6 +866,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Toucher/Preview Content\"";
 				DEVELOPMENT_TEAM = WF2V4JB29M;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
@@ -958,6 +991,31 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 29BCA2E22B5021AB009D6DEF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = "FirebaseStorageCombine-Community";
+		};
+		32AB7AC22B87B2E700DC6158 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 29BCA2E22B5021AB009D6DEF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		32AB7AC42B87B2E700DC6158 /* FirebaseAnalyticsOnDeviceConversion */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 29BCA2E22B5021AB009D6DEF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsOnDeviceConversion;
+		};
+		32AB7AC62B87B2E700DC6158 /* FirebaseAnalyticsSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 29BCA2E22B5021AB009D6DEF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsSwift;
+		};
+		32AB7AC82B87B2E700DC6158 /* FirebaseAnalyticsWithoutAdIdSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 29BCA2E22B5021AB009D6DEF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsWithoutAdIdSupport;
+		};
+		32AB7ACA2B87B2E700DC6158 /* FirebaseAppCheck */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 29BCA2E22B5021AB009D6DEF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAppCheck;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Toucher/Toucher.xcodeproj/xcshareddata/xcschemes/Toucher.xcscheme
+++ b/Toucher/Toucher.xcodeproj/xcshareddata/xcschemes/Toucher.xcscheme
@@ -49,6 +49,24 @@
             ReferencedContainer = "container:Toucher.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FiRDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-FiRDebugDisabled"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-FIRAnalyticsDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-FiRAnalyticsDebugDisabled"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"

--- a/Toucher/Toucher/Component/BackGroundColor.swift
+++ b/Toucher/Toucher/Component/BackGroundColor.swift
@@ -21,4 +21,3 @@ struct BackGroundColor: View {
         }
     }
 }
-

--- a/Toucher/Toucher/Component/Buttons/DoubleTapButton.swift
+++ b/Toucher/Toucher/Component/Buttons/DoubleTapButton.swift
@@ -39,6 +39,7 @@ struct DoubleTapButton: View {
                 before: TapGesture()
                     .onEnded {
                         FirestoreManager.shared.updateViewTapNumber(.doubleTap, .doubleTapButtonView)
+                        AnalyticsManager.shared.logEvent(name: "DoubleTapButtonView_Fail")
                     }
             )
     }
@@ -51,9 +52,12 @@ struct DoubleTapButton: View {
         if count >= 2 {
             isFail = false
             isSuccess = true
+            AnalyticsManager.shared.logEvent(name: "DoubleTapButtonView_Success")
         } else {
             isSuccess = false
             isFail = true
+            FirestoreManager.shared.updateViewTapNumber(.doubleTap, .doubleTapButtonView)
+            AnalyticsManager.shared.logEvent(name: "DoubleTapButtonView_Fail")
         }
         
         print("isSuccess : \(isSuccess)")

--- a/Toucher/Toucher/Component/Buttons/DoubleTapButton.swift
+++ b/Toucher/Toucher/Component/Buttons/DoubleTapButton.swift
@@ -52,7 +52,7 @@ struct DoubleTapButton: View {
         if count >= 2 {
             isFail = false
             isSuccess = true
-            AnalyticsManager.shared.logEvent(name: "DoubleTapButtonView_Success")
+            AnalyticsManager.shared.logEvent(name: "DoubleTapButtonView_ClearCount")
         } else {
             isSuccess = false
             isFail = true

--- a/Toucher/Toucher/Component/Buttons/FinishMainButton.swift
+++ b/Toucher/Toucher/Component/Buttons/FinishMainButton.swift
@@ -24,6 +24,7 @@ struct FinishMainButton: View {
             .offset(y: gesture == selectedGesture ? 5 : 0)
             .onTapGesture {
                 action()
+                AnalyticsManager.shared.logEvent(name: "\(gesture)_ButtonClicked")
             }
             .frame(maxWidth: .infinity)
     }

--- a/Toucher/Toucher/Component/Buttons/HelpButton.swift
+++ b/Toucher/Toucher/Component/Buttons/HelpButton.swift
@@ -108,6 +108,7 @@ struct HelpButton: View {
         Button {
             isFullScreenPresented.toggle()
             firestoreManager.updateHelpButtonData(gesture, viewName)
+            AnalyticsManager.shared.logEvent(name: "\(gesture)_HelpButtonClicked")
         } label: {
             Text("도움이 필요하신가요?")
                 .font(.customButton)

--- a/Toucher/Toucher/Component/Buttons/HelpButton.swift
+++ b/Toucher/Toucher/Component/Buttons/HelpButton.swift
@@ -108,7 +108,7 @@ struct HelpButton: View {
         Button {
             isFullScreenPresented.toggle()
             firestoreManager.updateHelpButtonData(gesture, viewName)
-            AnalyticsManager.shared.logEvent(name: "\(viewName)_HelpButtonClicked")
+            AnalyticsManager.shared.logEvent(name: "\(viewName)HelpButtonCount")
         } label: {
             Text("도움이 필요하신가요?")
                 .font(.customButton)

--- a/Toucher/Toucher/Component/Buttons/HelpButton.swift
+++ b/Toucher/Toucher/Component/Buttons/HelpButton.swift
@@ -108,7 +108,7 @@ struct HelpButton: View {
         Button {
             isFullScreenPresented.toggle()
             firestoreManager.updateHelpButtonData(gesture, viewName)
-            AnalyticsManager.shared.logEvent(name: "\(gesture)_HelpButtonClicked")
+            AnalyticsManager.shared.logEvent(name: "\(viewName)_HelpButtonClicked")
         } label: {
             Text("도움이 필요하신가요?")
                 .font(.customButton)

--- a/Toucher/Toucher/Component/Buttons/HelpButton.swift
+++ b/Toucher/Toucher/Component/Buttons/HelpButton.swift
@@ -108,7 +108,7 @@ struct HelpButton: View {
         Button {
             isFullScreenPresented.toggle()
             firestoreManager.updateHelpButtonData(gesture, viewName)
-            AnalyticsManager.shared.logEvent(name: "\(viewName)HelpButtonCount")
+            AnalyticsManager.shared.logEvent(name: "\(viewName)_HelpButtonCount")
         } label: {
             Text("도움이 필요하신가요?")
                 .font(.customButton)

--- a/Toucher/Toucher/Component/Buttons/LongPressButton.swift
+++ b/Toucher/Toucher/Component/Buttons/LongPressButton.swift
@@ -39,7 +39,7 @@ struct LongPressButton: View {
             .onEnded { finished in
                     isSuccess = finished
                     print("isSuccess : \(isSuccess)")
-                    AnalyticsManager.shared.logEvent(name: "LongTapButtoView_Success")
+                    AnalyticsManager.shared.logEvent(name: "LongTapButtoView_ClearCount")
             }
             .onChanged { value in
                 withAnimation {

--- a/Toucher/Toucher/Component/Buttons/LongPressButton.swift
+++ b/Toucher/Toucher/Component/Buttons/LongPressButton.swift
@@ -39,6 +39,7 @@ struct LongPressButton: View {
             .onEnded { finished in
                     isSuccess = finished
                     print("isSuccess : \(isSuccess)")
+                    AnalyticsManager.shared.logEvent(name: "LongTapButtoView_Success")
             }
             .onChanged { value in
                 withAnimation {
@@ -65,8 +66,9 @@ struct LongPressButton: View {
                         isTapStart = false
                         animation = [false, false, false]
                         print("isFail : \(isFail)")
-                        FirestoreManager.shared.updateViewTapNumber(.longPress, .longTapButtonView)
                     }
+                    FirestoreManager.shared.updateViewTapNumber(.longPress, .longTapButtonView)
+                    AnalyticsManager.shared.logEvent(name: "LongTapButtonView_Fail")
                 }
             )
     }

--- a/Toucher/Toucher/Component/Buttons/MainButton.swift
+++ b/Toucher/Toucher/Component/Buttons/MainButton.swift
@@ -51,6 +51,9 @@ struct MainButton: View {
                     startBubble
                 }
             }
+            .onTapGesture {
+                AnalyticsManager.shared.logEvent(name: "\(gesture)_ButtonClicked")
+            }
     }
     
     private var ellipseStroke: some View {

--- a/Toucher/Toucher/Component/Buttons/MainButton.swift
+++ b/Toucher/Toucher/Component/Buttons/MainButton.swift
@@ -51,9 +51,6 @@ struct MainButton: View {
                     startBubble
                 }
             }
-            .onTapGesture {
-                AnalyticsManager.shared.logEvent(name: "\(gesture)_ButtonClicked")
-            }
     }
     
     private var ellipseStroke: some View {

--- a/Toucher/Toucher/Component/Header/CustomToolbar.swift
+++ b/Toucher/Toucher/Component/Header/CustomToolbar.swift
@@ -70,7 +70,7 @@ struct CustomToolbar: View {
             .overlay(alignment: .leading) {
                 Button {
                     dismiss()
-                    AnalyticsManager.shared.logEvent(name: "\(viewName)_BackButtonClicked")
+                    AnalyticsManager.shared.logEvent(name: "\(viewName)BackButtonCount")
                 } label: {
                     HStack(spacing: 3) {
                         Image(systemName: "chevron.backward")

--- a/Toucher/Toucher/Component/Header/CustomToolbar.swift
+++ b/Toucher/Toucher/Component/Header/CustomToolbar.swift
@@ -11,7 +11,51 @@ struct CustomToolbar: View {
     @Environment(\.dismiss) var dismiss
     
     let title: LocalizedStringKey
+    
     var isSuccess = false
+    var selectedGuideVideo: URLManager
+    var viewName: ViewName {
+        switch selectedGuideVideo {
+        case .doubleTapButtonView:
+            return .doubleTapButtonView
+        case .doubleTapSearchBarView:
+            return .doubleTapSearchBarView
+        case .doubleTapImageView:
+            return .doubleTapImageView
+        case .longTapButtonView:
+            return .longTapButtonView
+        case .longTapCameraButtonView:
+            return .longTapCameraButtonView
+        case .longTapAlbumPhotoView:
+            return .longTapAlbumPhotoView
+        case .swipeCarouselView:
+            return .swipeCarouselView
+        case .swipeListView:
+            return .swipeListView
+        case .swipeMessageView:
+            return .swipeMessageView
+        case .dragIconView:
+            return .dragIconView
+        case .dragProgressBarView:
+            return .dragProgressBarView
+        case .dragAppIconView:
+            return .dragAppIconView
+        case .panNotificationView:
+            return .panNotificationView
+        case .panMapView:
+            return .panMapView
+        case .pinchIconZoomInView:
+            return .pinchIconZoomInView
+        case .pinchIconZoomOutView:
+            return .pinchIconZoomOutView
+        case .pinchImageView:
+            return .pinchImageView
+        case .rotateIconView:
+            return .rotateIconView
+        case .rotateMapView:
+            return .rotateMapView
+        }
+    }
     
     var body: some View {
         
@@ -26,6 +70,7 @@ struct CustomToolbar: View {
             .overlay(alignment: .leading) {
                 Button {
                     dismiss()
+                    AnalyticsManager.shared.logEvent(name: "\(viewName)_BackButtonClicked")
                 } label: {
                     HStack(spacing: 3) {
                         Image(systemName: "chevron.backward")
@@ -52,5 +97,5 @@ struct CustomToolbar: View {
 }
 
 #Preview {
-    CustomToolbar(title: "두번 누르기")
+    CustomToolbar(title: "두번 누르기", selectedGuideVideo: .doubleTapButtonView)
 }

--- a/Toucher/Toucher/Component/Header/CustomToolbar.swift
+++ b/Toucher/Toucher/Component/Header/CustomToolbar.swift
@@ -70,7 +70,7 @@ struct CustomToolbar: View {
             .overlay(alignment: .leading) {
                 Button {
                     dismiss()
-                    AnalyticsManager.shared.logEvent(name: "\(viewName)BackButtonCount")
+                    AnalyticsManager.shared.logEvent(name: "\(viewName)_BackButtonCount")
                 } label: {
                     HStack(spacing: 3) {
                         Image(systemName: "chevron.backward")

--- a/Toucher/Toucher/Component/PracticeBubble.swift
+++ b/Toucher/Toucher/Component/PracticeBubble.swift
@@ -66,6 +66,7 @@ struct PracticeBubble: View {
                 
                 Button {
                     action()
+                    AnalyticsManager.shared.logEvent(name: "\(gesture)_StartButtonClicked")
                 } label: {
                     Text("시작하기")
                         .font(.system(size: 22))

--- a/Toucher/Toucher/Manager/AnalyticsManager.swift
+++ b/Toucher/Toucher/Manager/AnalyticsManager.swift
@@ -1,0 +1,29 @@
+//
+//  TrackingManager.swift
+//  Toucher
+//
+//  Created by bulmang on 2/23/24.
+//
+
+import Foundation
+
+struct AnalyticsManager {
+    
+    private init() { }
+
+    struct Screen {
+        private init() { }
+
+        static let splash = "스플래시"
+        static let onboarding = "온보딩_진입"
+        static let main = "메인화면_진입"
+    }
+
+    struct Event {
+        private init() { }
+
+        static let touchOnboardingStart = "A2_온보딩_시작"
+        static let touchKakaoLogin = "A3_로그인_카카오"
+        static let touchAppleLogin = "A3_로그인_애플"
+    }
+}

--- a/Toucher/Toucher/Manager/AnalyticsManager.swift
+++ b/Toucher/Toucher/Manager/AnalyticsManager.swift
@@ -6,24 +6,24 @@
 //
 
 import Foundation
+import FirebaseAnalytics
+import FirebaseAnalyticsSwift
 
 struct AnalyticsManager {
     
+    static let shared = AnalyticsManager()
     private init() { }
-
-    struct Screen {
-        private init() { }
-
-        static let splash = "스플래시"
-        static let onboarding = "온보딩_진입"
-        static let main = "메인화면_진입"
+    
+    func logEvent(name: String, params: [String: Any]? = nil) {
+        Analytics.logEvent(name, parameters: params)
     }
-
-    struct Event {
-        private init() { }
-
-        static let touchOnboardingStart = "A2_온보딩_시작"
-        static let touchKakaoLogin = "A3_로그인_카카오"
-        static let touchAppleLogin = "A3_로그인_애플"
+    
+    func setUserId(userId: String) {
+        Analytics.setUserID(userId)
     }
+    
+    func setUserProperty(value: String?, property: String) {
+        Analytics.setUserProperty(value, forName: property)
+    }
+    
 }

--- a/Toucher/Toucher/Modifier/Firebase/FirebaseEndViewModifier.swift
+++ b/Toucher/Toucher/Modifier/Firebase/FirebaseEndViewModifier.swift
@@ -40,7 +40,7 @@ struct FirebaseEndViewModifier: ViewModifier {
                 if isSuccess {
                     firestoreManager.updateViewClearData(gesture, viewName)
                     firestoreManager.updateTotalClearData(gesture)
-                    AnalyticsManager.shared.logEvent(name: "\(gesture)ClearNumber")
+                    AnalyticsManager.shared.logEvent(name: "\(gesture)_ClearNumber")
                 } else {
                     firestoreManager.updateBackButtonData(gesture, viewName)
                 }

--- a/Toucher/Toucher/Modifier/Firebase/FirebaseEndViewModifier.swift
+++ b/Toucher/Toucher/Modifier/Firebase/FirebaseEndViewModifier.swift
@@ -40,7 +40,7 @@ struct FirebaseEndViewModifier: ViewModifier {
                 if isSuccess {
                     firestoreManager.updateViewClearData(gesture, viewName)
                     firestoreManager.updateTotalClearData(gesture)
-                    AnalyticsManager.shared.logEvent(name: "\(gesture)_ClearNumber")
+                    AnalyticsManager.shared.logEvent(name: "\(gesture)_ClearCount")
                 } else {
                     firestoreManager.updateBackButtonData(gesture, viewName)
                 }

--- a/Toucher/Toucher/Modifier/Firebase/FirebaseEndViewModifier.swift
+++ b/Toucher/Toucher/Modifier/Firebase/FirebaseEndViewModifier.swift
@@ -40,6 +40,7 @@ struct FirebaseEndViewModifier: ViewModifier {
                 if isSuccess {
                     firestoreManager.updateViewClearData(gesture, viewName)
                     firestoreManager.updateTotalClearData(gesture)
+                    AnalyticsManager.shared.logEvent(name: "\(gesture)ClearNumber")
                 } else {
                     firestoreManager.updateBackButtonData(gesture, viewName)
                 }

--- a/Toucher/Toucher/SceneDelegate.swift
+++ b/Toucher/Toucher/SceneDelegate.swift
@@ -44,6 +44,8 @@ extension SceneDelegate {
     private func signInAnonymously() {
         if let user = Auth.auth().currentUser {
             firestoreManager.getCurrentUser()
+            AnalyticsManager.shared.setUserId(userId: user.uid)
+            AnalyticsManager.shared.setUserProperty(value: true.description, property: user.uid)
             print("Log in \(user.uid)")
         } else {
             Auth.auth().signInAnonymously { authResult, error in

--- a/Toucher/Toucher/View/ContentView.swift
+++ b/Toucher/Toucher/View/ContentView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ContentView: View {
-    @AppStorage("finish") private var finish = true
+    @AppStorage("finish") private var finish = false
     @AppStorage("first") private var isFirst = true
     
     @State private var isSplashActive = true

--- a/Toucher/Toucher/View/ContentView.swift
+++ b/Toucher/Toucher/View/ContentView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ContentView: View {
-    @AppStorage("finish") private var finish = false
+    @AppStorage("finish") private var finish = true
     @AppStorage("first") private var isFirst = true
     
     @State private var isSplashActive = true

--- a/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapButtonView.swift
+++ b/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapButtonView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import FirebaseAnalytics
 
 struct DoubleTapButtonView: View {
     @AppStorage("createDoubleTap") var createDoubleTap = true
@@ -48,6 +49,7 @@ struct DoubleTapButtonView: View {
                 }
             }
         }
+        .analyticsScreen(name: "DoubleTapButtonView")
         .modifier(MoveToNextModifier(isNavigate: $doubleTapVM.isNavigate, isSuccess: $doubleTapVM.isSuccess))
         .navigationDestination(isPresented: $doubleTapVM.isNavigate) {
             DoubleTapSearchBarView()

--- a/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapButtonView.swift
+++ b/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapButtonView.swift
@@ -20,7 +20,7 @@ struct DoubleTapButtonView: View {
             BackGroundColor(isFail: doubleTapVM.isFail, isSuccess: doubleTapVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "두 번 누르기", isSuccess: doubleTapVM.isSuccess)
+                CustomToolbar(title: "두 번 누르기", isSuccess: doubleTapVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     VStack {

--- a/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapImageView.swift
+++ b/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapImageView.swift
@@ -71,7 +71,7 @@ struct DoubleTapImageView: View {
                 withAnimation {
                     doubleTapVM.isSuccess = true
                 }
-                AnalyticsManager.shared.logEvent(name: "DoubleTapImageView_Success")
+                AnalyticsManager.shared.logEvent(name: "DoubleTapImageView_ClearCount")
             }
             .exclusively(
                 before: TapGesture()

--- a/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapImageView.swift
+++ b/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapImageView.swift
@@ -18,7 +18,7 @@ struct DoubleTapImageView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            CustomToolbar(title: "두 번 누르기", isSuccess: doubleTapVM.isSuccess)
+            CustomToolbar(title: "두 번 누르기", isSuccess: doubleTapVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 .zIndex(1)
             
             ZStack {

--- a/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapImageView.swift
+++ b/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapImageView.swift
@@ -62,24 +62,25 @@ struct DoubleTapImageView: View {
                 doubleTapVM.reset()
             }
         }
+        .analyticsScreen(name: "DoubleTapImageView")
     }
     
     private var gesture: some Gesture {
         TapGesture(count: 2)
             .onEnded {
                 withAnimation {
-                    doubleTapVM.isSuccess.toggle()
-                    doubleTapVM.isTapped = true
+                    doubleTapVM.isSuccess = true
                 }
+                AnalyticsManager.shared.logEvent(name: "DoubleTapImageView_Success")
             }
             .exclusively(
                 before: TapGesture()
                     .onEnded {
                         withAnimation {
-                            doubleTapVM.isTapped.toggle()
                             doubleTapVM.isFail = true
-                            FirestoreManager.shared.updateViewTapNumber(.doubleTap, .doubleTapImageView)
                         }
+                        FirestoreManager.shared.updateViewTapNumber(.doubleTap, .doubleTapImageView)
+                        AnalyticsManager.shared.logEvent(name: "DoubleTapImagView_Fail")
                     })
     }
 }

--- a/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapSearchBarView.swift
+++ b/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapSearchBarView.swift
@@ -49,6 +49,7 @@ struct DoubleTapSearchBarView: View {
                 
             }
         }
+        .analyticsScreen(name: "DoubleTapSearchBarView")
         .modifier(MoveToNextModifier(isNavigate: $doubleTapVM.isNavigate, isSuccess: $doubleTapVM.isSuccess))
         .navigationDestination(isPresented: $doubleTapVM.isNavigate) {
             DoubleTapImageView()
@@ -97,6 +98,7 @@ struct DoubleTapSearchBarView: View {
                     doubleTapVM.isSuccess = true
                     doubleTapVM.isTapped = true
                 }
+                AnalyticsManager.shared.logEvent(name: "DoubleTapSearchBarView_Success")
             }
             .exclusively(
                 before: TapGesture()
@@ -104,8 +106,9 @@ struct DoubleTapSearchBarView: View {
                         withAnimation {
                             doubleTapVM.isTapped = true
                             doubleTapVM.isFail = true
-                            FirestoreManager.shared.updateViewTapNumber(.doubleTap, .doubleTapSearchBarView)
                         }
+                        FirestoreManager.shared.updateViewTapNumber(.doubleTap, .doubleTapSearchBarView)
+                        AnalyticsManager.shared.logEvent(name: "DoubleTapSearchBarView_Fail")
                     })
     }
 }

--- a/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapSearchBarView.swift
+++ b/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapSearchBarView.swift
@@ -19,7 +19,7 @@ struct DoubleTapSearchBarView: View {
             BackGroundColor(isFail: doubleTapVM.isFail, isSuccess: doubleTapVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "두 번 누르기", isSuccess: doubleTapVM.isSuccess)
+                CustomToolbar(title: "두 번 누르기", isSuccess: doubleTapVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     VStack {

--- a/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapSearchBarView.swift
+++ b/Toucher/Toucher/View/GestureView/DoubleTap/DoubleTapSearchBarView.swift
@@ -98,7 +98,7 @@ struct DoubleTapSearchBarView: View {
                     doubleTapVM.isSuccess = true
                     doubleTapVM.isTapped = true
                 }
-                AnalyticsManager.shared.logEvent(name: "DoubleTapSearchBarView_Success")
+                AnalyticsManager.shared.logEvent(name: "DoubleTapSearchBarView_ClearCount")
             }
             .exclusively(
                 before: TapGesture()

--- a/Toucher/Toucher/View/GestureView/Drag/DragAppIconView.swift
+++ b/Toucher/Toucher/View/GestureView/Drag/DragAppIconView.swift
@@ -26,7 +26,7 @@ struct DragAppIconView: View {
             BackGroundColor(isFail: dragVM.isFail, isSuccess: dragVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "끌어오기", isSuccess: dragVM.isSuccess)
+                CustomToolbar(title: "끌어오기", isSuccess: dragVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     VStack {

--- a/Toucher/Toucher/View/GestureView/Drag/DragAppIconView.swift
+++ b/Toucher/Toucher/View/GestureView/Drag/DragAppIconView.swift
@@ -91,6 +91,7 @@ struct DragAppIconView: View {
                             dragVM.isFail = true
                         }
                         FirestoreManager.shared.updateViewTapNumber(.drag, .dragAppIconView)
+                        AnalyticsManager.shared.logEvent(name: "DragAppIconView_Fail")
                     }
                     .overlay {
                         if dragVM.isSuccess {
@@ -100,6 +101,7 @@ struct DragAppIconView: View {
                 }
             }
         }
+        .analyticsScreen(name: "DragAppIconView")
         .modifier(
             FirebaseEndViewModifier(
                 isSuccess: dragVM.isSuccess,
@@ -111,6 +113,11 @@ struct DragAppIconView: View {
             dragVM.isSuccess = false
         }
         .modifier(FinishModifier(isNavigate: $dragVM.isNavigate, isSuccess: $dragVM.isSuccess))
+        .onChange(of: dragVM.isSuccess) { _ in
+            if dragVM.isSuccess {
+                AnalyticsManager.shared.logEvent(name: "DragAppIconView_Success")
+            }
+        }
     }
 }
 

--- a/Toucher/Toucher/View/GestureView/Drag/DragAppIconView.swift
+++ b/Toucher/Toucher/View/GestureView/Drag/DragAppIconView.swift
@@ -115,7 +115,7 @@ struct DragAppIconView: View {
         .modifier(FinishModifier(isNavigate: $dragVM.isNavigate, isSuccess: $dragVM.isSuccess))
         .onChange(of: dragVM.isSuccess) { _ in
             if dragVM.isSuccess {
-                AnalyticsManager.shared.logEvent(name: "DragAppIconView_Success")
+                AnalyticsManager.shared.logEvent(name: "DragAppIconView_ClearCount")
             }
         }
     }

--- a/Toucher/Toucher/View/GestureView/Drag/DragIconView.swift
+++ b/Toucher/Toucher/View/GestureView/Drag/DragIconView.swift
@@ -24,7 +24,7 @@ struct DragIconView: View {
             BackGroundColor(isFail: dragVM.isFail, isSuccess: dragVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "끌어오기", isSuccess: dragVM.isSuccess)
+                CustomToolbar(title: "끌어오기", isSuccess: dragVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     VStack {

--- a/Toucher/Toucher/View/GestureView/Drag/DragIconView.swift
+++ b/Toucher/Toucher/View/GestureView/Drag/DragIconView.swift
@@ -93,6 +93,7 @@ struct DragIconView: View {
                                                 withAnimation {
                                                     dragVM.isSuccess = true
                                                 }
+                                                AnalyticsManager.shared.logEvent(name: "DragIconView_Success")
                                             }
                                             
                                             if !isArrived {
@@ -102,6 +103,7 @@ struct DragIconView: View {
                                                     dragVM.isTapped = false
                                                     dragVM.isFail = true
                                                 }
+                                                AnalyticsManager.shared.logEvent(name: "DragIconView_Fail")
                                             }
                                         }
                                         .simultaneously(with: LongPressGesture(minimumDuration: 0)
@@ -132,6 +134,7 @@ struct DragIconView: View {
                 }
             }
         }
+        .analyticsScreen(name: "DragIconView")
         .modifier(MoveToNextModifier(isNavigate: $dragVM.isNavigate, isSuccess: $dragVM.isSuccess))
         .navigationDestination(isPresented: $dragVM.isNavigate) {
             DragProgressBarView()

--- a/Toucher/Toucher/View/GestureView/Drag/DragIconView.swift
+++ b/Toucher/Toucher/View/GestureView/Drag/DragIconView.swift
@@ -93,7 +93,7 @@ struct DragIconView: View {
                                                 withAnimation {
                                                     dragVM.isSuccess = true
                                                 }
-                                                AnalyticsManager.shared.logEvent(name: "DragIconView_Success")
+                                                AnalyticsManager.shared.logEvent(name: "DragIconView_ClearCount")
                                             }
                                             
                                             if !isArrived {

--- a/Toucher/Toucher/View/GestureView/Drag/DragProgressBarView.swift
+++ b/Toucher/Toucher/View/GestureView/Drag/DragProgressBarView.swift
@@ -63,6 +63,11 @@ struct DragProgressBarView: View {
             dragVM.reset()
             value = 0.0
         }
+        .onChange(of: dragVM.isSuccess) { isSuccess in
+            if isSuccess {
+                AnalyticsManager.shared.logEvent(name: "DragProgressBarView_Success")
+            }
+        }
     }
     
     private var slider: some View {
@@ -92,7 +97,6 @@ struct DragProgressBarView: View {
             .onChange(of: value) { newValue in
                 if newValue >= 0.3 {
                     dragVM.isSuccess = true
-                    AnalyticsManager.shared.logEvent(name: "DragProgressBarView_Success")
                 }
             }
         }

--- a/Toucher/Toucher/View/GestureView/Drag/DragProgressBarView.swift
+++ b/Toucher/Toucher/View/GestureView/Drag/DragProgressBarView.swift
@@ -47,6 +47,7 @@ struct DragProgressBarView: View {
                 }
             }
         }
+        .analyticsScreen(name: "DragProgressBarView")
         .modifier(MoveToNextModifier(isNavigate: $dragVM.isNavigate, isSuccess: $dragVM.isSuccess))
         .navigationDestination(isPresented: $dragVM.isNavigate) {
             DragAppIconView()
@@ -70,6 +71,7 @@ struct DragProgressBarView: View {
                 .onTapGesture {
                     if !dragVM.isSuccess {
                         dragVM.isFail = true
+                        AnalyticsManager.shared.logEvent(name: "DragProgressBarView_Fail")
                     }
                 }
             Group {
@@ -90,6 +92,7 @@ struct DragProgressBarView: View {
             .onChange(of: value) { newValue in
                 if newValue >= 0.3 {
                     dragVM.isSuccess = true
+                    AnalyticsManager.shared.logEvent(name: "DragProgressBarView_Success")
                 }
             }
         }

--- a/Toucher/Toucher/View/GestureView/Drag/DragProgressBarView.swift
+++ b/Toucher/Toucher/View/GestureView/Drag/DragProgressBarView.swift
@@ -19,7 +19,7 @@ struct DragProgressBarView: View {
             BackGroundColor(isFail: dragVM.isFail, isSuccess: dragVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "끌어오기", isSuccess: dragVM.isSuccess)
+                CustomToolbar(title: "끌어오기", isSuccess: dragVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     VStack {

--- a/Toucher/Toucher/View/GestureView/Drag/DragProgressBarView.swift
+++ b/Toucher/Toucher/View/GestureView/Drag/DragProgressBarView.swift
@@ -65,7 +65,7 @@ struct DragProgressBarView: View {
         }
         .onChange(of: dragVM.isSuccess) { isSuccess in
             if isSuccess {
-                AnalyticsManager.shared.logEvent(name: "DragProgressBarView_Success")
+                AnalyticsManager.shared.logEvent(name: "DragProgressBarView_ClearCount")
             }
         }
     }

--- a/Toucher/Toucher/View/GestureView/LongTap/LongTapAlbumPhotoView.swift
+++ b/Toucher/Toucher/View/GestureView/LongTap/LongTapAlbumPhotoView.swift
@@ -80,15 +80,17 @@ struct LongTapAlbumPhotoView: View {
                                                     scale = 1
                                                     selectedIndex = index
                                                 }
+                                                AnalyticsManager.shared.logEvent(name: "LongTapAlubmPhotoView_Success")
                                             }
                                             .simultaneously(with: TapGesture()
                                                 .onEnded {
                                                     withAnimation {
                                                         longTapVM.isTapped = true
                                                         longTapVM.isFail = true
-                                                        FirestoreManager.shared.updateViewTapNumber(.longPress, .longTapAlbumPhotoView)
                                                         scale = 1
                                                     }
+                                                    FirestoreManager.shared.updateViewTapNumber(.longPress, .longTapAlbumPhotoView)
+                                                    AnalyticsManager.shared.logEvent(name: "LongTapAlbumView_Fail")
                                                 })
                                     )
                             }
@@ -136,6 +138,7 @@ struct LongTapAlbumPhotoView: View {
                 }
             }
         }
+        .analyticsScreen(name: "LongTapAlbumPhotoView")
         .modifier(FinishModifier(isNavigate: $longTapVM.isNavigate, isSuccess: $longTapVM.isSuccess))
         .modifier(
             FirebaseEndViewModifier(

--- a/Toucher/Toucher/View/GestureView/LongTap/LongTapAlbumPhotoView.swift
+++ b/Toucher/Toucher/View/GestureView/LongTap/LongTapAlbumPhotoView.swift
@@ -27,7 +27,7 @@ struct LongTapAlbumPhotoView: View {
                 Color.customSecondary.ignoresSafeArea()
             }
             VStack(spacing: 0) {
-                CustomToolbar(title: "길게 누르기", isSuccess: longTapVM.isSuccess)
+                CustomToolbar(title: "길게 누르기", isSuccess: longTapVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ScrollView {
                     Text(longTapVM.isSuccess ? "성공!\n" : longTapVM.isFail ? "조금 더 길게 꾹 \n눌러주세요!" : "앨범의 사진을 꾹 눌러서\n미리 보아 볼까요?")

--- a/Toucher/Toucher/View/GestureView/LongTap/LongTapAlbumPhotoView.swift
+++ b/Toucher/Toucher/View/GestureView/LongTap/LongTapAlbumPhotoView.swift
@@ -80,7 +80,7 @@ struct LongTapAlbumPhotoView: View {
                                                     scale = 1
                                                     selectedIndex = index
                                                 }
-                                                AnalyticsManager.shared.logEvent(name: "LongTapAlubmPhotoView_Success")
+                                                AnalyticsManager.shared.logEvent(name: "LongTapAlubmPhotoView_ClearCount")
                                             }
                                             .simultaneously(with: TapGesture()
                                                 .onEnded {

--- a/Toucher/Toucher/View/GestureView/LongTap/LongTapButtonView.swift
+++ b/Toucher/Toucher/View/GestureView/LongTap/LongTapButtonView.swift
@@ -19,7 +19,7 @@ struct LongTapButtonView: View {
             BackGroundColor(isFail: longTapVM.isFail, isSuccess: longTapVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "길게 누르기", isSuccess: longTapVM.isSuccess)
+                CustomToolbar(title: "길게 누르기", isSuccess: longTapVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     VStack {

--- a/Toucher/Toucher/View/GestureView/LongTap/LongTapButtonView.swift
+++ b/Toucher/Toucher/View/GestureView/LongTap/LongTapButtonView.swift
@@ -58,6 +58,7 @@ struct LongTapButtonView: View {
                     .toolbar(.hidden, for: .navigationBar)
             }
         }
+        .analyticsScreen(name: "LongTapButtonView")
         .modifier(FirebaseStartViewModifier(create: $createLongTap, isSuccess: longTapVM.isSuccess, viewName: .longTapButtonView))
         .onAppear {
             longTapVM.reset()

--- a/Toucher/Toucher/View/GestureView/LongTap/LongTapCameraButtonView.swift
+++ b/Toucher/Toucher/View/GestureView/LongTap/LongTapCameraButtonView.swift
@@ -20,7 +20,7 @@ struct LongTapCameraButtonView: View {
             BackGroundColor(isFail: longTapVM.isFail, isSuccess: longTapVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "길게 누르기", isSuccess: longTapVM.isSuccess)
+                CustomToolbar(title: "길게 누르기", isSuccess: longTapVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     VStack {

--- a/Toucher/Toucher/View/GestureView/LongTap/LongTapCameraButtonView.swift
+++ b/Toucher/Toucher/View/GestureView/LongTap/LongTapCameraButtonView.swift
@@ -58,6 +58,7 @@ struct LongTapCameraButtonView: View {
                     .toolbar(.hidden, for: .navigationBar)
             }
         }
+        .analyticsScreen(name: "LongTapCameraButtonView")
         .modifier(
             FirebaseViewModifier(
                 isSuccess: longTapVM.isSuccess,
@@ -90,6 +91,7 @@ struct LongTapCameraButtonView: View {
                             longTapVM.isSuccess = true
                             longTapVM.isTapped = true
                         }
+                        AnalyticsManager.shared.logEvent(name: "LongTapCameraButtonView_Success")
                     }
                     .simultaneously(with: TapGesture()
                         .onEnded {
@@ -98,6 +100,7 @@ struct LongTapCameraButtonView: View {
                                 longTapVM.isFail = true
                             }
                             FirestoreManager.shared.updateViewTapNumber(.longPress, .longTapCameraButtonView)
+                            AnalyticsManager.shared.logEvent(name: "LongTapCamerButtonView_Fail")
                         })
             )
             .background(alignment: .topLeading) {

--- a/Toucher/Toucher/View/GestureView/LongTap/LongTapCameraButtonView.swift
+++ b/Toucher/Toucher/View/GestureView/LongTap/LongTapCameraButtonView.swift
@@ -91,7 +91,7 @@ struct LongTapCameraButtonView: View {
                             longTapVM.isSuccess = true
                             longTapVM.isTapped = true
                         }
-                        AnalyticsManager.shared.logEvent(name: "LongTapCameraButtonView_Success")
+                        AnalyticsManager.shared.logEvent(name: "LongTapCameraButtonView_ClearCount")
                     }
                     .simultaneously(with: TapGesture()
                         .onEnded {

--- a/Toucher/Toucher/View/GestureView/Main/FinishMain/FinishMainView.swift
+++ b/Toucher/Toucher/View/GestureView/Main/FinishMain/FinishMainView.swift
@@ -49,6 +49,7 @@ struct FinishMainView: View {
                 }
             }
         }
+        .analyticsScreen(name: "FinishMainView")
         .overlay(alignment: .top) {
             Text("자유롭게 눌러 학습하세요!")
                 .font(.system(size: 22))

--- a/Toucher/Toucher/View/GestureView/Main/MainView.swift
+++ b/Toucher/Toucher/View/GestureView/Main/MainView.swift
@@ -49,6 +49,7 @@ struct MainView: View {
             MainViewHeader(gesture: navigationManager.headerGesture)
                 .frame(maxHeight: .infinity, alignment: .top)
         }
+        .analyticsScreen(name: "MainView")
         .navigationDestination(isPresented: $navigationManager.navigate) {
             navigationManager.navigateGestureView(gesture: navigationManager.headerGesture)
                 .toolbar(.hidden, for: .navigationBar)

--- a/Toucher/Toucher/View/GestureView/Pan/PanMapView.swift
+++ b/Toucher/Toucher/View/GestureView/Pan/PanMapView.swift
@@ -27,14 +27,16 @@ struct PanMapView: View {
                                 withAnimation {
                                     panVM.isSuccess = true
                                 }
+                                AnalyticsManager.shared.logEvent(name: "PanMapView_Success")
                             }
                             .exclusively(
                                 before: TapGesture()
                                     .onEnded {
                                         withAnimation {
                                             panVM.isFail = true
-                                            FirestoreManager.shared.updateViewTapNumber(.pan, .panMapView)
                                         }
+                                        FirestoreManager.shared.updateViewTapNumber(.pan, .panMapView)
+                                        AnalyticsManager.shared.logEvent(name: "PanMapView_Fail")
                                     })
                     )
                 
@@ -89,6 +91,7 @@ struct PanMapView: View {
                 panVM.reset()
             }
         }
+        .analyticsScreen(name: "PanMapView")
     }
 }
 

--- a/Toucher/Toucher/View/GestureView/Pan/PanMapView.swift
+++ b/Toucher/Toucher/View/GestureView/Pan/PanMapView.swift
@@ -27,7 +27,7 @@ struct PanMapView: View {
                                 withAnimation {
                                     panVM.isSuccess = true
                                 }
-                                AnalyticsManager.shared.logEvent(name: "PanMapView_Success")
+                                AnalyticsManager.shared.logEvent(name: "PanMapView_ClearCount")
                             }
                             .exclusively(
                                 before: TapGesture()

--- a/Toucher/Toucher/View/GestureView/Pan/PanMapView.swift
+++ b/Toucher/Toucher/View/GestureView/Pan/PanMapView.swift
@@ -15,7 +15,7 @@ struct PanMapView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            CustomToolbar(title: "화면 움직이기", isSuccess: panVM.isSuccess)
+            CustomToolbar(title: "화면 움직이기", isSuccess: panVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 .zIndex(1)
             
             ZStack {

--- a/Toucher/Toucher/View/GestureView/Pan/PanNotificationView.swift
+++ b/Toucher/Toucher/View/GestureView/Pan/PanNotificationView.swift
@@ -113,8 +113,10 @@ struct PanNotificationView: View {
                                         perform: { value in
                                             if value >= scrollViewSize.height - wholeSize.height {
                                                 panVM.isSuccess = true
+                                                AnalyticsManager.shared.logEvent(name: "PanNotificationView_Success")
                                             } else if value < 0 {
                                                 panVM.isFail = true
+                                                AnalyticsManager.shared.logEvent(name: "PanNotificationView_Fail")
                                             } else {
                                                 panVM.isFail = false
                                             }
@@ -131,6 +133,7 @@ struct PanNotificationView: View {
                             panVM.isFail = true
                         }
                         FirestoreManager.shared.updateViewTapNumber(.pan, .panNotificationView)
+                        AnalyticsManager.shared.logEvent(name: "PanNotificationView_Fail")
                     }
                     .onChange(
                         of: scrollViewSize,
@@ -148,6 +151,7 @@ struct PanNotificationView: View {
                 }
             }
         }
+        .analyticsScreen(name: "PanNotificationView")
         .modifier(
             FirebaseStartViewModifier(
                 create: $createPan,

--- a/Toucher/Toucher/View/GestureView/Pan/PanNotificationView.swift
+++ b/Toucher/Toucher/View/GestureView/Pan/PanNotificationView.swift
@@ -37,7 +37,7 @@ struct PanNotificationView: View {
             BackGroundColor(isFail: panVM.isFail, isSuccess: panVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "화면 움직이기", isSuccess: panVM.isSuccess)
+                CustomToolbar(title: "화면 움직이기", isSuccess: panVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     VStack {

--- a/Toucher/Toucher/View/GestureView/Pan/PanNotificationView.swift
+++ b/Toucher/Toucher/View/GestureView/Pan/PanNotificationView.swift
@@ -169,7 +169,7 @@ struct PanNotificationView: View {
         .modifier(MoveToNextModifier(isNavigate: $panVM.isNavigate, isSuccess: $panVM.isSuccess))
         .onChange(of: panVM.isSuccess) { isSuccess in
             if isSuccess {
-                AnalyticsManager.shared.logEvent(name: "PanNotification_Success")
+                AnalyticsManager.shared.logEvent(name: "PanNotification_ClearCount")
             }
         }
         .navigationDestination(isPresented: $panVM.isNavigate) {

--- a/Toucher/Toucher/View/GestureView/Pan/PanNotificationView.swift
+++ b/Toucher/Toucher/View/GestureView/Pan/PanNotificationView.swift
@@ -113,7 +113,6 @@ struct PanNotificationView: View {
                                         perform: { value in
                                             if value >= scrollViewSize.height - wholeSize.height {
                                                 panVM.isSuccess = true
-                                                AnalyticsManager.shared.logEvent(name: "PanNotificationView_Success")
                                             } else if value < 0 {
                                                 panVM.isFail = true
                                                 AnalyticsManager.shared.logEvent(name: "PanNotificationView_Fail")
@@ -168,6 +167,11 @@ struct PanNotificationView: View {
             }
         }
         .modifier(MoveToNextModifier(isNavigate: $panVM.isNavigate, isSuccess: $panVM.isSuccess))
+        .onChange(of: panVM.isSuccess) { isSuccess in
+            if isSuccess {
+                AnalyticsManager.shared.logEvent(name: "PanNotification_Success")
+            }
+        }
         .navigationDestination(isPresented: $panVM.isNavigate) {
             PanMapView()
                 .toolbar(.hidden, for: .navigationBar)

--- a/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomInView.swift
+++ b/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomInView.swift
@@ -92,7 +92,7 @@ struct PinchIconZoomInView: View {
                 withAnimation {
                     if scale > 1.5 {
                         pinchVM.isSuccess = true
-                        AnalyticsManager.shared.logEvent(name: "PinchIconZoomInView_Success")
+                        AnalyticsManager.shared.logEvent(name: "PinchIconZoomInView_ClearCount")
                         HapticManager.notification(type: .success)
                         self.scale = 2
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {

--- a/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomInView.swift
+++ b/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomInView.swift
@@ -77,6 +77,7 @@ struct PinchIconZoomInView: View {
                 PinchIconZoomOutView()
             }
         }
+        .analyticsScreen(name: "PinchIconZoomInView")
     }
     
     private var gesture: some Gesture {
@@ -91,6 +92,7 @@ struct PinchIconZoomInView: View {
                 withAnimation {
                     if scale > 1.5 {
                         pinchVM.isSuccess = true
+                        AnalyticsManager.shared.logEvent(name: "PinchIconZoomInView_Success")
                         HapticManager.notification(type: .success)
                         self.scale = 2
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
@@ -106,6 +108,7 @@ struct PinchIconZoomInView: View {
                             pinchVM.isFail = true
                         }
                         FirestoreManager.shared.updateViewTapNumber(.pinch, .pinchIconZoomInView)
+                        AnalyticsManager.shared.logEvent(name: "PinchIconZoomInView_Fail")
                     }
             )
             .simultaneously(
@@ -114,6 +117,7 @@ struct PinchIconZoomInView: View {
                         withAnimation {
                             pinchVM.isFail = true
                         }
+                        AnalyticsManager.shared.logEvent(name: "PinchIconZoomInView_Fail")
                     }
             )
     }

--- a/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomInView.swift
+++ b/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomInView.swift
@@ -21,7 +21,7 @@ struct PinchIconZoomInView: View {
             
             if !pinchVM.isNavigate {
                 VStack {
-                    CustomToolbar(title: "확대 축소하기", isSuccess: pinchVM.isSuccess)
+                    CustomToolbar(title: "확대 축소하기", isSuccess: pinchVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                     
                     ZStack {
                         VStack {

--- a/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomOutView.swift
+++ b/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomOutView.swift
@@ -19,7 +19,7 @@ struct PinchIconZoomOutView: View {
             BackGroundColor(isFail: pinchVM.isFail, isSuccess: pinchVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "확대 축소하기", isSuccess: pinchVM.isSuccess)
+                CustomToolbar(title: "확대 축소하기", isSuccess: pinchVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     VStack {

--- a/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomOutView.swift
+++ b/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomOutView.swift
@@ -95,7 +95,7 @@ struct PinchIconZoomOutView: View {
                 withAnimation {
                     if scale < 0.8 {
                         pinchVM.isSuccess = true
-                        AnalyticsManager.shared.logEvent(name: "PinchIconZoomOutView_Success")
+                        AnalyticsManager.shared.logEvent(name: "PinchIconZoomOutView_ClearCount")
                         self.scale = 0.6
                     }
                 }

--- a/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomOutView.swift
+++ b/Toucher/Toucher/View/GestureView/Pinch/PinchIconZoomOutView.swift
@@ -80,6 +80,7 @@ struct PinchIconZoomOutView: View {
                 scale = 1
             }
         }
+        .analyticsScreen(name: "PinchIconZoomOutView")
     }
     
     private var gesture: some Gesture {
@@ -94,6 +95,7 @@ struct PinchIconZoomOutView: View {
                 withAnimation {
                     if scale < 0.8 {
                         pinchVM.isSuccess = true
+                        AnalyticsManager.shared.logEvent(name: "PinchIconZoomOutView_Success")
                         self.scale = 0.6
                     }
                 }
@@ -105,6 +107,7 @@ struct PinchIconZoomOutView: View {
                             pinchVM.isFail = true
                         }
                         FirestoreManager.shared.updateViewTapNumber(.pinch, .pinchIconZoomOutView)
+                        AnalyticsManager.shared.logEvent(name: "PinchIconZoomOutView_Fail")
                     }
             )
             .simultaneously(
@@ -113,6 +116,7 @@ struct PinchIconZoomOutView: View {
                         withAnimation {
                             pinchVM.isFail = true
                         }
+                        AnalyticsManager.shared.logEvent(name: "PinchIconZoomOutView_Fail")
                     }
             )
     }

--- a/Toucher/Toucher/View/GestureView/Pinch/PinchImageView.swift
+++ b/Toucher/Toucher/View/GestureView/Pinch/PinchImageView.swift
@@ -17,7 +17,7 @@ struct PinchImageView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            CustomToolbar(title: "확대 축소하기", isSuccess: pinchVM.isSuccess)
+            CustomToolbar(title: "확대 축소하기", isSuccess: pinchVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 .zIndex(1)
             
             ZStack {

--- a/Toucher/Toucher/View/GestureView/Pinch/PinchImageView.swift
+++ b/Toucher/Toucher/View/GestureView/Pinch/PinchImageView.swift
@@ -82,7 +82,7 @@ struct PinchImageView: View {
                 withAnimation {
                     if scale > 1.2 {
                         pinchVM.isSuccess = true
-                        AnalyticsManager.shared.logEvent(name: "PinchImageView_Success")
+                        AnalyticsManager.shared.logEvent(name: "PinchImageView_ClearCount")
                         self.scale = 3
                     } else {
                         pinchVM.isFail = true

--- a/Toucher/Toucher/View/GestureView/Pinch/PinchImageView.swift
+++ b/Toucher/Toucher/View/GestureView/Pinch/PinchImageView.swift
@@ -60,6 +60,7 @@ struct PinchImageView: View {
                     .frame(maxHeight: .infinity, alignment: .bottom)
             }
         }
+        .analyticsScreen(name: "PinchImageView")
         .modifier(FinishModifier(isNavigate: $pinchVM.isNavigate, isSuccess: $pinchVM.isSuccess))
         .modifier(
             FirebaseEndViewModifier(
@@ -81,10 +82,12 @@ struct PinchImageView: View {
                 withAnimation {
                     if scale > 1.2 {
                         pinchVM.isSuccess = true
+                        AnalyticsManager.shared.logEvent(name: "PinchImageView_Success")
                         self.scale = 3
                     } else {
                         pinchVM.isFail = true
                         FirestoreManager.shared.updateViewTapNumber(.pinch, .pinchImageView)
+                        AnalyticsManager.shared.logEvent(name: "PinchImageView_Fail")
                     }
                 }
             }

--- a/Toucher/Toucher/View/GestureView/Rotate/RotateIconView.swift
+++ b/Toucher/Toucher/View/GestureView/Rotate/RotateIconView.swift
@@ -114,7 +114,7 @@ struct RotateIconView: View {
                     withAnimation {
                         rotateVM.isSuccess = true
                     }
-                    AnalyticsManager.shared.logEvent(name: "RotateIconView_Success")
+                    AnalyticsManager.shared.logEvent(name: "RotateIconView_ClearCount")
                 } else {
                     print(accumulateAngle.degrees)
                     rotateVM.isSuccess = false

--- a/Toucher/Toucher/View/GestureView/Rotate/RotateIconView.swift
+++ b/Toucher/Toucher/View/GestureView/Rotate/RotateIconView.swift
@@ -23,7 +23,7 @@ struct RotateIconView: View {
             BackGroundColor(isFail: rotateVM.isFail, isSuccess: rotateVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "회전하기", isSuccess: rotateVM.isSuccess)
+                CustomToolbar(title: "회전하기", isSuccess: rotateVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 ZStack {
                     VStack {
                         Text(rotateVM.isSuccess ? "성공!\n" : rotateVM.isFail ? "두 손가락을 동시에\n움직여보세요!" : "두 손가락을 원 위에 대고\n회전시켜볼까요?")

--- a/Toucher/Toucher/View/GestureView/Rotate/RotateIconView.swift
+++ b/Toucher/Toucher/View/GestureView/Rotate/RotateIconView.swift
@@ -59,6 +59,7 @@ struct RotateIconView: View {
                                 rotateVM.isFail = true
                             }
                             FirestoreManager.shared.updateViewTapNumber(.rotate, .rotateIconView)
+                            AnalyticsManager.shared.logEvent(name: "RotateIconView_Fail")
                         }
                         .overlay {
                             if rotateVM.isSuccess {
@@ -77,6 +78,7 @@ struct RotateIconView: View {
                 }
             }
         }
+        .analyticsScreen(name: "RotateIconView")
         .modifier(MoveToNextModifier(isNavigate: $rotateVM.isNavigate, isSuccess: $rotateVM.isSuccess))
         .navigationDestination(isPresented: $rotateVM.isNavigate) {
             RotateMapView()
@@ -112,10 +114,12 @@ struct RotateIconView: View {
                     withAnimation {
                         rotateVM.isSuccess = true
                     }
+                    AnalyticsManager.shared.logEvent(name: "RotateIconView_Success")
                 } else {
                     print(accumulateAngle.degrees)
                     rotateVM.isSuccess = false
                     rotateVM.isFail = true
+                    AnalyticsManager.shared.logEvent(name: "RotateIconView_Fail")
                 }
             }
     }

--- a/Toucher/Toucher/View/GestureView/Rotate/RotateMapView.swift
+++ b/Toucher/Toucher/View/GestureView/Rotate/RotateMapView.swift
@@ -22,7 +22,7 @@ struct RotateMapView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            CustomToolbar(title: "회전하기", isSuccess: rotateVM.isSuccess)
+            CustomToolbar(title: "회전하기", isSuccess: rotateVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 .zIndex(1)
             
             ZStack {

--- a/Toucher/Toucher/View/GestureView/Rotate/RotateMapView.swift
+++ b/Toucher/Toucher/View/GestureView/Rotate/RotateMapView.swift
@@ -40,14 +40,16 @@ struct RotateMapView: View {
                                     .onEnded {
                                         withAnimation {
                                             rotateVM.isFail = true
-                                            FirestoreManager.shared.updateViewTapNumber(.rotate, .rotateMapView)
                                         }
+                                        FirestoreManager.shared.updateViewTapNumber(.rotate, .rotateMapView)
+                                        AnalyticsManager.shared.logEvent(name: "RotateMapView_Fail")
                                     })
 
                     )
                     .onChange(of: heading) { _ in
                         if abs(heading) > 10 {
                             rotateVM.isSuccess = true
+                            AnalyticsManager.shared.logEvent(name: "RotateMapView_Fail")
                         }
                     }
                     .overlay {
@@ -76,6 +78,7 @@ struct RotateMapView: View {
                     .frame(maxHeight: .infinity, alignment: .bottom)
             }
         }
+        .analyticsScreen(name: "RotateMapView")
         .modifier(FinishModifier(isNavigate: $rotateVM.isNavigate, isSuccess: $rotateVM.isSuccess))
         .modifier(
             FirebaseEndViewModifier(

--- a/Toucher/Toucher/View/GestureView/Rotate/RotateMapView.swift
+++ b/Toucher/Toucher/View/GestureView/Rotate/RotateMapView.swift
@@ -49,7 +49,11 @@ struct RotateMapView: View {
                     .onChange(of: heading) { _ in
                         if abs(heading) > 10 {
                             rotateVM.isSuccess = true
-                            AnalyticsManager.shared.logEvent(name: "RotateMapView_Fail")
+                        }
+                    }
+                    .onChange(of: rotateVM.isSuccess) { isSuccess in
+                        if isSuccess {
+                            AnalyticsManager.shared.logEvent(name: "RotateMapView_ClearCount")
                         }
                     }
                     .overlay {

--- a/Toucher/Toucher/View/GestureView/Swipe/SwipeCarouselView.swift
+++ b/Toucher/Toucher/View/GestureView/Swipe/SwipeCarouselView.swift
@@ -32,7 +32,7 @@ struct SwipeCarouselView: View {
             BackGroundColor(isFail: swipeVM.isFail, isSuccess: swipeVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "살짝 쓸기", isSuccess: swipeVM.isSuccess)
+                CustomToolbar(title: "살짝 쓸기", isSuccess: swipeVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 titleText
                     .foregroundColor(swipeVM.isFail && !swipeVM.isSuccess ? Color.customWhite : Color.black)

--- a/Toucher/Toucher/View/GestureView/Swipe/SwipeCarouselView.swift
+++ b/Toucher/Toucher/View/GestureView/Swipe/SwipeCarouselView.swift
@@ -180,7 +180,7 @@ struct SwipeCarouselView: View {
             if array[lastIndex] == 0 && array[lastIndex - 1] == 1 {
                 swipeVM.isSuccess = true
                 swipeVM.isFail = false
-                AnalyticsManager.shared.logEvent(name: "SwipeCarouselView_Success")
+                AnalyticsManager.shared.logEvent(name: "SwipeCarouselView_ClearCount")
             } else if array[lastIndex] != array[lastIndex - 1] {
                 swipeVM.isSuccess = false
                 swipeVM.isFail = false

--- a/Toucher/Toucher/View/GestureView/Swipe/SwipeCarouselView.swift
+++ b/Toucher/Toucher/View/GestureView/Swipe/SwipeCarouselView.swift
@@ -82,6 +82,7 @@ struct SwipeCarouselView: View {
                     .toolbar(.hidden, for: .navigationBar)
             }
         }
+        .analyticsScreen(name: "SwipeCarouselView")
     }
     
     private var titleText: some View {
@@ -121,6 +122,7 @@ struct SwipeCarouselView: View {
                         swipeVM.isFail = true
                     }
                     FirestoreManager.shared.updateViewTapNumber(.swipe, .swipeCarouselView)
+                    AnalyticsManager.shared.logEvent(name: "SwipeCarouselView_Fail")
                 }
         )
         .gesture(
@@ -159,13 +161,35 @@ struct SwipeCarouselView: View {
                 let roundIndex = progress.rounded()
                 currentIndex = errorHandleArray(roundIndex)
                 currentIndexArray.append(currentIndex)
-                swipeVM.checkSuccessCondition(currentIndexArray)
+                checkSuccessCondition(currentIndexArray)
             }
     }
     
     ///  현재 swipeContent 개수 만큼 Swipe가 가능하게 만들어 주는 함수 (에러 방지)
     private func errorHandleArray(_ roundIndex: CGFloat) -> Int {
         return max(min(currentIndex + Int(roundIndex), swipeContent.count - 1), 0)
+    }
+    /// SwipeExampleView 성공 조건 감지
+    private func checkSuccessCondition(_ array: [Int]) {
+        let lastIndex = array.count - 1
+        if array[lastIndex] == 0 {
+            swipeVM.isFail = true
+            AnalyticsManager.shared.logEvent(name: "SwipeCarouselView_Fail")
+        }
+        if array.count >= 2 {
+            if array[lastIndex] == 0 && array[lastIndex - 1] == 1 {
+                swipeVM.isSuccess = true
+                swipeVM.isFail = false
+                AnalyticsManager.shared.logEvent(name: "SwipeCarouselView_Success")
+            } else if array[lastIndex] != array[lastIndex - 1] {
+                swipeVM.isSuccess = false
+                swipeVM.isFail = false
+            } else {
+                swipeVM.isSuccess = false
+                swipeVM.isFail = true
+                AnalyticsManager.shared.logEvent(name: "SwipeCarouselView_Fail")
+            }
+        }
     }
 }
 

--- a/Toucher/Toucher/View/GestureView/Swipe/SwipeListView.swift
+++ b/Toucher/Toucher/View/GestureView/Swipe/SwipeListView.swift
@@ -20,7 +20,7 @@ struct SwipeListView: View {
             BackGroundColor(isFail: swipeVM.isFail, isSuccess: swipeVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "살짝 쓸기", isSuccess: swipeVM.isSuccess)
+                CustomToolbar(title: "살짝 쓸기", isSuccess: swipeVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     VStack {

--- a/Toucher/Toucher/View/GestureView/Swipe/SwipeListView.swift
+++ b/Toucher/Toucher/View/GestureView/Swipe/SwipeListView.swift
@@ -148,7 +148,7 @@ struct SwipeListView: View {
                                         swipeVM.isFail = false
                                         textIndex = 2
                                         swipeVM.isSuccess = true
-                                        AnalyticsManager.shared.logEvent(name: "SwipeListView_Success")
+                                        AnalyticsManager.shared.logEvent(name: "SwipeListView_ClearCount")
                                     }
                                     
                                 }

--- a/Toucher/Toucher/View/GestureView/Swipe/SwipeListView.swift
+++ b/Toucher/Toucher/View/GestureView/Swipe/SwipeListView.swift
@@ -81,6 +81,7 @@ struct SwipeListView: View {
                                                     withAnimation {
                                                         swipeVM.isFail = true
                                                     }
+                                                    AnalyticsManager.shared.logEvent(name: "SwipeListView_Fail")
                                                 }
                                             }
                                         }
@@ -91,6 +92,7 @@ struct SwipeListView: View {
                                                         swipeVM.isFail = true
                                                     }
                                                     FirestoreManager.shared.updateViewTapNumber(.swipe, .swipeListView)
+                                                    AnalyticsManager.shared.logEvent(name: "SwipeListView_Fail")
                                                 })
                                 )
                                 .swipeActions(allowsFullSwipe: false) {
@@ -146,6 +148,7 @@ struct SwipeListView: View {
                                         swipeVM.isFail = false
                                         textIndex = 2
                                         swipeVM.isSuccess = true
+                                        AnalyticsManager.shared.logEvent(name: "SwipeListView_Success")
                                     }
                                     
                                 }
@@ -165,6 +168,7 @@ struct SwipeListView: View {
                 }
             }
         }
+        .analyticsScreen(name: "SwipeListView")
         .modifier(
             FirebaseViewModifier(
                 isSuccess: swipeVM.isSuccess,

--- a/Toucher/Toucher/View/GestureView/Swipe/SwipeMessageView.swift
+++ b/Toucher/Toucher/View/GestureView/Swipe/SwipeMessageView.swift
@@ -50,6 +50,7 @@ struct SwipeMessageView: View {
                                                                     swipeVM.isFail = true
                                                                 }
                                                             }
+                                                            AnalyticsManager.shared.logEvent(name: "SwipeMessageView_Fail")
                                                         }
                                                     }
                                             )
@@ -69,6 +70,7 @@ struct SwipeMessageView: View {
                                 Button(role: .destructive) {
                                     swipeVM.isFail = false
                                     swipeVM.isSuccess = true
+                                    AnalyticsManager.shared.logEvent(name: "SwipeMessageView_Success")
                                     if let index = swipeVM.messageData.firstIndex(where: { $0.id == message.id }) {
                                         swipeVM.messageData.remove(at: index)
                                     }
@@ -100,6 +102,7 @@ struct SwipeMessageView: View {
                 }
             }
         }
+        .analyticsScreen(name: "SwipeMessageView")
         .overlay {
             if swipeVM.isSuccess {
                 ConfettiView()

--- a/Toucher/Toucher/View/GestureView/Swipe/SwipeMessageView.swift
+++ b/Toucher/Toucher/View/GestureView/Swipe/SwipeMessageView.swift
@@ -70,7 +70,7 @@ struct SwipeMessageView: View {
                                 Button(role: .destructive) {
                                     swipeVM.isFail = false
                                     swipeVM.isSuccess = true
-                                    AnalyticsManager.shared.logEvent(name: "SwipeMessageView_Success")
+                                    AnalyticsManager.shared.logEvent(name: "SwipeMessageView_ClearCount")
                                     if let index = swipeVM.messageData.firstIndex(where: { $0.id == message.id }) {
                                         swipeVM.messageData.remove(at: index)
                                     }

--- a/Toucher/Toucher/View/GestureView/Swipe/SwipeMessageView.swift
+++ b/Toucher/Toucher/View/GestureView/Swipe/SwipeMessageView.swift
@@ -17,7 +17,7 @@ struct SwipeMessageView: View {
             BackGroundColor(isFail: swipeVM.isFail, isSuccess: swipeVM.isSuccess)
             
             VStack {
-                CustomToolbar(title: "살짝 쓸기", isSuccess: swipeVM.isSuccess)
+                CustomToolbar(title: "살짝 쓸기", isSuccess: swipeVM.isSuccess, selectedGuideVideo: selectedGuideVideo)
                 
                 ZStack {
                     Text(swipeVM.isFail ? "왼쪽으로\n살짝 쓸어보세요.\n" : swipeVM.isSuccess ? "성공!\n\n" : "메시지를 왼쪽으로 밀어서\n삭제해 보세요\n")

--- a/Toucher/Toucher/View/GestureView/Swipe/SwipeViewModel.swift
+++ b/Toucher/Toucher/View/GestureView/Swipe/SwipeViewModel.swift
@@ -25,23 +25,4 @@ class SwipeViewModel: ObservableObject {
         isSuccess = false
     }
     
-    /// SwipeExampleView 성공 조건 감지
-    func checkSuccessCondition(_ array: [Int]) {
-        let lastIndex = array.count - 1
-        if array[lastIndex] == 0 {
-            self.isFail = true
-        }
-        if array.count >= 2 {
-            if array[lastIndex] == 0 && array[lastIndex - 1] == 1 {
-                self.isSuccess = true
-                self.isFail = false
-            } else if array[lastIndex] != array[lastIndex - 1] {
-                self.isSuccess = false
-                self.isFail = false
-            } else {
-                self.isSuccess = false
-                self.isFail = true
-            }
-        }
-    }
 }


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 및 번호 (optional)
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
-   #94  

<br>

## ✨ Description
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
Google Analytics 연결을 하였습니다.
Analytics Manager 구조체를 싱클토으로 생성하여 성공과 실패일때 Log를 GA에 보내도록 하였습니다.
### AnalyticsManager
```

struct AnalyticsManager {
    
    static let shared = AnalyticsManager()
    private init() { }
    
    func logEvent(name: String, params: [String: Any]? = nil) {
        Analytics.logEvent(name, parameters: params)
    }
    
    func setUserId(userId: String) {
        Analytics.setUserID(userId)
    }
    
    func setUserProperty(value: String?, property: String) {
        Analytics.setUserProperty(value, forName: property)
    }
    
}
```

### 페이지 화면 전송
`.analyticsScreen(name: "FinishMainView")`를 사용하여 유저가 화면에 진입하였을 때 GA에 화면 진입 기록을 전송합니다.

### 유저 정보값 전송
`SceneDelegate`에 아래 코드를 추가하여 uid값과 유저의 정보에 대해 GA전송하게 됩니다.
```
AnalyticsManager.shared.setUserId(userId: user.uid)
AnalyticsManager.shared.setUserProperty(value: true.description, property: user.uid)
```
 
 ###  View별 ClearCount 전송
 `AnalyticsManager.shared.logEvent(name: "RotateMapView_ClearCount")'을 사용하여 ClearCount Data를 전송합니다.

### View별 Fail 전송
`AnalyticsManager.shared.logEvent(name: "RotateMapView_Fail")`을 사용하여 Fail Data를 전송합니다.

### BackButton
`AnalyticsManager.shared.logEvent(name: "\(viewName)_BackButtonCount")`을 사용하여 ViewBackButtonCount Data를 전송합니다.

### HelpButton
`AnalyticsManager.shared.logEvent(name: "\(viewName)_HelpButtonCount")`을 사용하여 HelpButtonCount Data를 전송합니다.
<br>

### Gesture별 ClearCount 전송
`AnalyticsManager.shared.logEvent(name: "\(gesture)_ClearCount")`을 사용하여 GestureClearCount Data를 전송합니다.

## 🏷️ Reference (optional)
<!-- 참고사항이나 레퍼런스 -->

<br>

## Screenshot
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|기능|스크린샷|
|:--:|:--:|
|Realtime Analytics|<img src = "https://github.com/ToucherTeam/Toucher/assets/114594496/a07f08c3-93f6-4d1f-b5c3-76d0722c4c5c" width ="550">|
|Debug View|<img src = "https://github.com/ToucherTeam/Toucher/assets/114594496/2f28fc90-8c0f-4dbf-9c57-addb711439fd" width ="550">|
|Debug View|<img src = "https://github.com/ToucherTeam/Toucher/assets/114594496/105998ab-e8e7-445e-ac02-3bcdb2b1077a" width ="550">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
Analytics Dashboard에 Data 반영이 24시간~48시간정도 걸린다고 합니다.